### PR TITLE
Support new cointype for Secret Ledger App

### DIFF
--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -34,6 +34,9 @@ const (
 
 	// DefaultKeyPass contains the default key password for genesis transactions
 	DefaultKeyPass = "12345678"
+
+	// Default CoinType for Secret Ledger App
+	DefaultLedgerCoinType = 529
 )
 
 // AddKeyCommand defines a keys command to add a generated or recovered private key to keybase.
@@ -208,7 +211,7 @@ func runAddCmd(ctx client.Context, cmd *cobra.Command, args []string, inBuf *buf
 		if legacyHdPath {
 			coinType = sdk.CoinType
 		} else {
-			return errors.New("ledger does not currently support new coin type. Use the legacy hd path flag")
+			coinType = DefaultLedgerCoinType
 		}
 
 		bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()


### PR DESCRIPTION
For the upcoming Secret Ledger App (currently in testing by Ledger), we need to have a working version of secretcli which supports the Secret Network BIP44 cointype 529. This sets the default cointype to 529 (instead of the old default of 118 before with the --legacy-hd-path option) when adding keys with the "keys add --ledger" option. 
